### PR TITLE
Fix next images

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,12 @@ const config = {
   reactStrictMode: true,
   images: {
     domains: ["void.cat"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+    ],
   },
 
   /**

--- a/src/components/ui/contributors.tsx
+++ b/src/components/ui/contributors.tsx
@@ -13,6 +13,8 @@ export function Contributors() {
       >
         <Image
           src="https://avatars.githubusercontent.com/u/1653275?s=64&amp;v=4"
+          width={64}
+          height={64}
           alt="@fiatjaf"
           className="rounded-full"
         />
@@ -28,6 +30,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/57707?s=64&amp;v=4"
           alt="@scsibug"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -42,6 +46,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/65864?s=64&amp;v=4"
           alt="@melvincarvalho"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -56,6 +62,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/18631614?s=64&amp;v=4"
           alt="@hieblmi"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -70,6 +78,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/3998?s=64&amp;v=4"
           alt="@srid"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -84,6 +94,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/7641?s=64&amp;v=4"
           alt="@asoltys"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -98,6 +110,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/45598?s=64&amp;v=4"
           alt="@jb55"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -112,6 +126,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/397451?s=64&amp;v=4"
           alt="@schulterklopfer"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -126,6 +142,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/967793?s=64&amp;v=4"
           alt="@GlenCooper"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -140,6 +158,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/1818366?s=64&amp;v=4"
           alt="@Kukks"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>
@@ -154,6 +174,8 @@ export function Contributors() {
         <Image
           src="https://avatars.githubusercontent.com/u/10324237?s=64&amp;v=4"
           alt="@verretor"
+          width={64}
+          height={64}
           className="rounded-full"
         />
       </a>


### PR DESCRIPTION
### What does it do? Why?

- Add `width` and `height` to all `Images`
- Add avatar.github.com `hostname` to `next.config.js`

![image](https://user-images.githubusercontent.com/79455860/223994053-0834e6f9-5e12-43e4-9e2f-9542f72e6de0.png)


### QA

Check if you still have the images issue

### Review

- [ ] All GHA are success
- [ ] Use https://ui.shadcn.com/docs often as possible
      more to come...
