### PR TITLE
Change Sign in from dropdown to two buttons

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -109,49 +109,63 @@ export function Header() {
     <header className="flex h-14 w-full items-center justify-between bg-[#171B21] px-8">
       <MainNav items={HeaderConfig.mainNav} />
       <div className="hidden items-center md:inline">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <div className="flex items-center cursor-pointer">
-              <Avatar className="w-8 h-8">
-                <AvatarImage src={picture} />
-                <AvatarFallback>{initials}</AvatarFallback>
-              </Avatar>
-              <ChevronDown className="mt-1 h-4 w-4 hover:text-white/80" />
-            </div>
-          </DropdownMenuTrigger>
-          {isLoggedIn ? (
-            <DropdownMenuContent className="w-56">
-              <DropdownMenuLabel>Signed in as {name}</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                {PrimaryGitInfo?.map((item) => (
-                  <DropdownMenuItem key={item.title}>
-                    <span>{item.title}</span>
-                  </DropdownMenuItem>
-                ))}
+        {
+          isLoggedIn ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <div className="flex items-center cursor-pointer">
+                  <Avatar className="w-8 h-8">
+                    <AvatarImage src={picture} />
+                    <AvatarFallback>{initials}</AvatarFallback>
+                  </Avatar>
+                  <ChevronDown className="mt-1 h-4 w-4 hover:text-white/80" />
+                </div>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56">
+                <DropdownMenuLabel>Signed in as {name}</DropdownMenuLabel>
                 <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                  {PrimaryGitInfo?.map((item) => (
+                    <DropdownMenuItem key={item.title}>
+                      <span>{item.title}</span>
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
 
-                {restGitInfo?.map((item) => (
-                  <DropdownMenuItem key={item.title}>
-                    <span>{item.title}</span>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem>
-                <Button onClick={handleSignOut}>Sign Out</Button>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
+                  {restGitInfo?.map((item) => (
+                    <DropdownMenuItem key={item.title}>
+                      <span>{item.title}</span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                  <Button
+                    variant={"outline"}
+                    type="submit"
+                    onClick={handleSignOut}
+                  >Sign Out</Button>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           ) : (
-            <DropdownMenuContent className="w-56 mt-2 mr-10">
-              <DropdownMenuItem>
-                <Link className="text-white" href="/login">
-                  Sign in
-                </Link>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          )}
-        </DropdownMenu>
+            <div className="flex gap-1 bg">
+              <Button
+                variant={"success"}
+                type="submit"
+                className="mr-2"
+              >
+                <Link className="text-white" href="/login">Sign in</Link>
+              </Button>
+              <Button
+                variant={"outline"}
+                type="submit"
+              >
+                <Link className="text-white" href="/signup">Sign up</Link>
+              </Button>
+            </div>
+          )
+        }
       </div>
     </header>
   );


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp; Closes #138. Change Sign in from a dropdown to two buttons: Sign in & Sign up.
👉🏻 &nbsp; Change Sign out button variant to 'outline' to reduce such a big contrast change when hovering.

Logged out:
![Screenshot from 2023-03-09 19-20-32](https://user-images.githubusercontent.com/82510823/224107503-60c3aa5f-7c37-4934-a987-c219986b14f3.png)

Logged in:
![Screenshot from 2023-03-09 19-22-45](https://user-images.githubusercontent.com/82510823/224107610-64f85d5c-79d0-4d20-92ab-db436a351745.png)


### QA

👉🏻 &nbsp; Check that all related buttons are working as expected.

### Review

- [ ] All GHA are success
- [ ] Use https://ui.shadcn.com/docs often as possible
      more to come...
