### PR TITLE
first attempt

### DIFF
--- a/src/app/issues/assigned/page.tsx
+++ b/src/app/issues/assigned/page.tsx
@@ -1,0 +1,7 @@
+export default function RepoDiscussionsPage() {
+  return (
+    <>
+      <h1>assigned</h1>
+    </>
+  );
+}

--- a/src/app/issues/assigned/page.tsx
+++ b/src/app/issues/assigned/page.tsx
@@ -1,4 +1,4 @@
-export default function RepoDiscussionsPage() {
+export default function IssuesAssignedPage() {
   return (
     <>
       <h1>assigned</h1>

--- a/src/app/issues/layout.tsx
+++ b/src/app/issues/layout.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import * as React from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import { clsx } from "clsx";
+import { Search } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function RepoLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname() || "";
+
+  const [issueType, setIssueType] = useState<
+    "created" | "assigned" | "mentioned" | ""
+  >("");
+
+  const [search, setSearch] = useState<string>(``);
+
+  useEffect(() => {
+    if (pathname.includes("issues/assigned")) {
+      setIssueType("assigned");
+      setSearch(`is:open is:issue assignee:xxxxx archived:false`);
+    } else if (pathname.includes("issues/mentioned")) {
+      setIssueType("mentioned");
+      setSearch(`is:open is:issue mentions:xxxxx archived:false`);
+    } else {
+      setIssueType("created");
+      setSearch(`is:open is:issue author:xxxxx archived:false`);
+    }
+  }, [pathname]);
+
+  const handleSearch = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      setSearch(e.currentTarget.value),
+    []
+  );
+
+  return (
+    <section className="sm:px-8 py-6 max-w-6xl m-auto">
+      <div className="md:flex justify-between gap-4 px-4 sm:px-0">
+        <div className="">
+          <span className="isolate inline-flex rounded-md shadow-sm w-full">
+            <Link
+              href={`/issues/`}
+              type="button"
+              className={clsx(
+                "relative inline-flex w-full md:w-min items-center rounded-l-md px-4 py-1.5 font-semibold text-slate-300 ring-1 ring-inset ring-slate-600 focus:z-10",
+                {
+                  "bg-purple-600 text-slate-50": issueType === `created`,
+                }
+              )}
+            >
+              Created
+            </Link>
+            <Link
+              href={`/issues/assigned`}
+              type="button"
+              className={clsx(
+                "relative inline-flex w-full md:w-min items-center rounded-l-md px-4 py-1.5 font-semibold text-slate-300 ring-1 ring-inset ring-slate-600 focus:z-10",
+                {
+                  "bg-purple-600 text-slate-50": issueType === `assigned`,
+                }
+              )}
+            >
+              Assigned
+            </Link>
+            <Link
+              href={`/issues/mentioned`}
+              type="button"
+              className={clsx(
+                "relative inline-flex w-full md:w-min items-center rounded-l-md px-4 py-1.5 font-semibold text-slate-300 ring-1 ring-inset ring-slate-600 focus:z-10",
+                {
+                  "bg-purple-600 text-slate-50": issueType === `mentioned`,
+                }
+              )}
+            >
+              Mentioned
+            </Link>
+          </span>
+        </div>
+
+        <label className="relative w-full border-slate-600 text-slate-400 border rounded-md">
+          <span className="sr-only">Search</span>
+          <span className="absolute inset-y-0 left-0 flex items-center px-2">
+            <Search className="h-4 w-4" />
+          </span>
+          <input
+            className="block bg-[#0E1116] w-full h-full rounded-md py-1 pl-9 pr-3 focus:outline-none focus:border-purple-500 focus:ring-purple-500 focus:ring-1 text-sm md:text-base"
+            type="text"
+            value={search}
+            onChange={handleSearch}
+          />
+        </label>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/app/issues/mentioned/page.tsx
+++ b/src/app/issues/mentioned/page.tsx
@@ -1,0 +1,7 @@
+export default function RepoDiscussionsPage() {
+  return (
+    <>
+      <h1>mentioned</h1>
+    </>
+  );
+}

--- a/src/app/issues/mentioned/page.tsx
+++ b/src/app/issues/mentioned/page.tsx
@@ -1,4 +1,4 @@
-export default function RepoDiscussionsPage() {
+export default function IssuesMentionedPage() {
   return (
     <>
       <h1>mentioned</h1>

--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -9,10 +9,10 @@ import {
   CheckCircle2,
   ChevronDown,
   CircleDot,
-  GitMerge,
+  GitPullRequest,
   MessageSquare,
-  Search,
 } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 
 interface IIssueData {
   id: string;
@@ -31,15 +31,14 @@ interface IIssueData {
 }
 
 export default function IssuesPage({}) {
-  const [issueType, setIssueType] = useState<
-    "created" | "assigned" | "mentioned"
-  >("created");
-
-  const [search, setSearch] = useState<string>(
-    `is:open is:issue author:xxxxx archived:false`
-  );
   const [issues, setIssues] = useState<IIssueData[]>(openData);
   const [issueStatus, setIssueStatus] = useState<"open" | "closed">("open");
+
+  const searchParams = useSearchParams()!;
+
+  const is = searchParams.get("is");
+
+  console.log("is ====> ", is);
 
   useEffect(() => {
     if (issueStatus === "open") {
@@ -49,185 +48,111 @@ export default function IssuesPage({}) {
     }
   }, [issueStatus]);
 
-  const handleSearch = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      setSearch(e.currentTarget.value),
-    []
-  );
-
   const handleIssueStatusOpen = useCallback(() => setIssueStatus("open"), []);
   const handleIssueStatusClosed = useCallback(
     () => setIssueStatus("closed"),
     []
   );
 
-  const handleIssueTypeCreated = useCallback(() => setIssueType("created"), []);
-  const handleIssueTypeAssigned = useCallback(
-    () => setIssueType("assigned"),
-    []
-  );
-  const handleIssueTypeMentioned = useCallback(
-    () => setIssueType("mentioned"),
-    []
-  );
-
   return (
-    <section className="sm:px-8 py-6 max-w-6xl m-auto">
-      <div className="md:flex justify-between gap-4 px-4 sm:px-0">
-        <div className="">
-          <span className="isolate inline-flex rounded-md shadow-sm w-full">
-            <button
-              type="button"
-              className={clsx(
-                "relative inline-flex w-full md:w-min items-center rounded-l-md px-4 py-1.5 font-semibold text-slate-300 ring-1 ring-inset ring-slate-600 focus:z-10",
-                {
-                  "bg-purple-600 text-slate-50": issueType === `created`,
-                }
-              )}
-              onClick={handleIssueTypeCreated}
-            >
-              Created
-            </button>
-            <button
-              type="button"
-              className={clsx(
-                "relative -ml-px inline-flex w-full md:w-min items-center px-4 py-1.5 font-semibold text-slate-300 ring-1 ring-inset ring-slate-600 focus:z-10",
-                {
-                  "bg-purple-600 text-slate-50": issueType === `assigned`,
-                }
-              )}
-              onClick={handleIssueTypeAssigned}
-            >
-              Assigned
-            </button>
-            <button
-              type="button"
-              className={clsx(
-                "relative -ml-px inline-flex w-full md:w-min items-center rounded-r-md px-4 py-1.5 font-semibold text-slate-300 ring-1 ring-inset ring-slate-600 focus:z-10",
-                {
-                  "bg-purple-600 text-slate-50": issueType === `mentioned`,
-                }
-              )}
-              onClick={handleIssueTypeMentioned}
-            >
-              Mentioned
-            </button>
-          </span>
-        </div>
-
-        <label className="relative w-full border-slate-600 text-slate-400 border rounded-md">
-          <span className="sr-only">Search</span>
-          <span className="absolute inset-y-0 left-0 flex items-center px-2">
-            <Search className="h-4 w-4" />
-          </span>
-          <input
-            className="block bg-[#0E1116] w-full h-full rounded-md py-1 pl-9 pr-3 focus:outline-none focus:border-purple-500 focus:ring-purple-500 focus:ring-1 text-sm md:text-base"
-            type="text"
-            value={search}
-            onChange={handleSearch}
-          />
-        </label>
-      </div>
-
-      <main>
-        <div className="mt-4">
-          <div className="flex w-full rounded-md rounded-bl-none rounded-br-none border bg-[#171B21] py-2 px-4 dark:border-[#383B42] dark:text-slate-100">
-            <div className="md:flex w-full flex-col text-md py-2 items-start justify-between lg:flex-row lg:items-center">
-              <div className="flex items-center lg:flex-row space-x-4 font-medium">
-                <button
-                  className={clsx("flex text-slate-400 hover:text-slate-200", {
-                    "text-slate-50": issueStatus === `open`,
-                  })}
-                  onClick={handleIssueStatusOpen}
-                >
-                  <CircleDot className="h-5 w-5 mr-2 mt-0.5" /> 3 Open
-                </button>
-                <button
-                  className={clsx("flex text-slate-400 hover:text-slate-200", {
-                    "text-slate-50": issueStatus === `closed`,
-                  })}
-                  onClick={handleIssueStatusClosed}
-                >
-                  <Check className="h-5 w-5 mr-2 mt-0.5" /> 4 Closed
-                </button>
-              </div>
-              <div className="mt-2 flex text-gray-400 lg:mt-0 space-x-6">
-                <span className="flex text-slate-400 hover:text-slate-200 cursor-pointer">
-                  Visibility <ChevronDown className="h-4 w-4 ml-1 mt-1.5" />
-                </span>
-                <span className="flex text-slate-400 hover:text-slate-200 cursor-pointer">
-                  Organization <ChevronDown className="h-4 w-4 ml-1 mt-1.5" />
-                </span>
-                <span className="flex text-slate-400 hover:text-slate-200 cursor-pointer">
-                  Sort <ChevronDown className="h-4 w-4 ml-1 mt-1.5" />
-                </span>
-              </div>
+    <main>
+      <div className="mt-4">
+        <div className="flex w-full rounded-md rounded-bl-none rounded-br-none border bg-[#171B21] py-2 px-4 dark:border-[#383B42] dark:text-slate-100">
+          <div className="md:flex w-full flex-col text-md py-2 items-start justify-between lg:flex-row lg:items-center">
+            <div className="flex items-center lg:flex-row space-x-4 font-medium">
+              <button
+                className={clsx("flex text-slate-400 hover:text-slate-200", {
+                  "text-slate-50": issueStatus === `open`,
+                })}
+                onClick={handleIssueStatusOpen}
+              >
+                <CircleDot className="h-5 w-5 mr-2 mt-0.5" /> 3 Open
+              </button>
+              <button
+                className={clsx("flex text-slate-400 hover:text-slate-200", {
+                  "text-slate-50": issueStatus === `closed`,
+                })}
+                onClick={handleIssueStatusClosed}
+              >
+                <Check className="h-5 w-5 mr-2 mt-0.5" /> 4 Closed
+              </button>
+            </div>
+            <div className="mt-2 flex text-gray-400 lg:mt-0 space-x-6">
+              <span className="flex text-slate-400 hover:text-slate-200 cursor-pointer">
+                Visibility <ChevronDown className="h-4 w-4 ml-1 mt-1.5" />
+              </span>
+              <span className="flex text-slate-400 hover:text-slate-200 cursor-pointer">
+                Organization <ChevronDown className="h-4 w-4 ml-1 mt-1.5" />
+              </span>
+              <span className="flex text-slate-400 hover:text-slate-200 cursor-pointer">
+                Sort <ChevronDown className="h-4 w-4 ml-1 mt-1.5" />
+              </span>
             </div>
           </div>
-          <div className="overflow-hidden rounded-md rounded-tr-none rounded-tl-none border border-t-0 dark:border-gray">
-            <ul className="divide-y dark:divide-gray">
-              {issues.map((item) => (
-                <li
-                  key={`${item.id} ${item.entity}`}
-                  className="text-gray-400 grid grid-cols-8 p-2 text-sm hover:bg-[#171B21]"
-                >
-                  <div className="col-span-8 sm:col-span-6">
-                    <div className="sm:flex items-center text-lg font-medium">
-                      <span className="flex">
-                        {issueStatus === "open" ? (
-                          <CircleDot className="h-5 w-5 mr-2 mt-1 text-green-600" />
-                        ) : (
-                          <CheckCircle2 className="h-5 w-5 mr-2 mt-1 text-purple-600" />
-                        )}
-                        <a
-                          className="text-slate-400 hover:text-purple-500"
-                          href="#"
-                        >
-                          {item.entity}/{item.repo}
-                        </a>
-                      </span>
-
+        </div>
+        <div className="overflow-hidden rounded-md rounded-tr-none rounded-tl-none border border-t-0 dark:border-gray">
+          <ul className="divide-y dark:divide-gray">
+            {issues.map((item) => (
+              <li
+                key={`${item.id} ${item.entity}`}
+                className="text-gray-400 grid grid-cols-8 p-2 text-sm hover:bg-[#171B21]"
+              >
+                <div className="col-span-8 sm:col-span-6">
+                  <div className="sm:flex items-center text-lg font-medium">
+                    <span className="flex">
+                      {issueStatus === "open" ? (
+                        <CircleDot className="h-5 w-5 mr-2 mt-1 text-green-600" />
+                      ) : (
+                        <CheckCircle2 className="h-5 w-5 mr-2 mt-1 text-purple-600" />
+                      )}
                       <a
-                        className="text-slate-200 hover:text-purple-500 pl-7 sm:pl-3"
+                        className="text-slate-400 hover:text-purple-500"
                         href="#"
                       >
-                        {item.title}
+                        {item.entity}/{item.repo}
                       </a>
-                    </div>
-                    <div className="ml-7 text-slate-400">
-                      #{item.number} opened {item.date} by{" "}
-                      <a className="hover:text-purple-500" href="#">
-                        {item.author}
-                      </a>
-                    </div>
-                  </div>
+                    </span>
 
-                  <div className="hidden sm:flex col-span-2 text-slate-400 justify-between pt-2 text-right pr-3 no-wrap">
-                    <span className="ml-2 flex hover:text-purple-500 cursor-pointer font-medium">
-                      {item.linkedPR ? (
-                        <>
-                          <GitMerge className="h-5 w-5 mr-2" />
-                          {item.linkedPR}
-                        </>
-                      ) : null}
-                    </span>
-                    <span className="ml-2 "></span>
-                    <span className="ml-2 flex hover:text-purple-500 cursor-pointer font-medium">
-                      {item.comments ? (
-                        <>
-                          <MessageSquare className="h-5 w-5 mr-2" />
-                          {item.comments}
-                        </>
-                      ) : null}
-                    </span>
+                    <a
+                      className="text-slate-200 hover:text-purple-500 pl-7 sm:pl-3"
+                      href="#"
+                    >
+                      {item.title}
+                    </a>
                   </div>
-                </li>
-              ))}
-            </ul>
-          </div>
+                  <div className="ml-7 text-slate-400">
+                    #{item.number} opened {item.date} by{" "}
+                    <a className="hover:text-purple-500" href="#">
+                      {item.author}
+                    </a>
+                  </div>
+                </div>
+
+                <div className="hidden sm:flex col-span-2 text-slate-400 justify-between pt-2 text-right pr-3 no-wrap">
+                  <span className="ml-2 flex hover:text-purple-500 cursor-pointer font-medium">
+                    {item.linkedPR ? (
+                      <>
+                        <GitPullRequest className="h-5 w-5 mr-2" />
+                        {item.linkedPR}
+                      </>
+                    ) : null}
+                  </span>
+                  <span className="ml-2 "></span>
+                  <span className="ml-2 flex hover:text-purple-500 cursor-pointer font-medium">
+                    {item.comments ? (
+                      <>
+                        <MessageSquare className="h-5 w-5 mr-2" />
+                        {item.comments}
+                      </>
+                    ) : null}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
-      </main>
-    </section>
+      </div>
+    </main>
   );
 }
 

--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -36,9 +36,9 @@ export default function IssuesPage({}) {
 
   const searchParams = useSearchParams()!;
 
-  const is = searchParams.get("is");
+  const q = searchParams.get("q");
 
-  console.log("is ====> ", is);
+  console.log("q ====> ", q);
 
   useEffect(() => {
     if (issueStatus === "open") {


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Please add a description of what this `pull request` does.
This PR is an attempt to look at the structure of the `/issues` page and how to handle page navigation and querying similar to github. 


### QA

👉🏻 &nbsp;Please add what you think the reviewer has to test.
This might not be the best time to implement and might have to wait until backend data objects and types is discovered.

This is an important thought because pages `/issues` and `/pulls` handle this very similar 

Also `/[entity]/[repo]/issues` and `/[entity]/[repo]/pulls` use a similar pattern for the search input

layouts do not support [useSearchParams](https://beta.nextjs.org/docs/api-reference/use-search-params#layouts), but pages do

github handles the close through the query, and only on the `/issues` page for `Created`,  `Assigned` and `Mentioned` buttons

challenges would be how to handle the search input between child and parent

### Review

- [ ] All GHA are success
- [ ] Use https://ui.shadcn.com/docs often as possible
      more to come...
