### PR TITLE
/discussions MVP using nostr, needs correct event (and refactor to react)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-dom": "18.2.0",
     "tailwind-merge": "^1.10.0",
     "tailwindcss-animate": "^1.0.5",
-    "ws": "^8.12.1",
+    "ws": "^8.13.0",
     "zod": "^3.20.6"
   },
   "devDependencies": {

--- a/src/app/[entity]/[repo]/discussions/page.tsx
+++ b/src/app/[entity]/[repo]/discussions/page.tsx
@@ -1,7 +1,33 @@
+// TODO: turn all of those imported scripts into more lightweight react components
+// change 503941a9939a4337d9aef7b92323c353441cb5ebe79f13fed77aeac615116354 to the correct event (once posted)
+
+import Script from 'next/script'
+
 export default function RepoDiscussionsPage() {
   return (
     <>
-      <h1>Discussions</h1>
+      <Script src="https://nostrocket.org/verifyBitcoinSignedMessage.js" />
+      <Script src="https://unpkg.com/nostr-tools/lib/nostr.bundle.js" />
+      <Script src="https://nostrocket.org/nostr.js" />
+      <Script src="https://nostrocket.org/comments.js" />
+      <link rel="stylesheet" href="https://nostrocket.org/comments.css" />
+      <Script
+        id="comments-init"
+        strategy="lazyOnload"
+        dangerouslySetInnerHTML={{
+          __html: `let relay = comments_init("503941a9939a4337d9aef7b92323c353441cb5ebe79f13fed77aeac615116354")`,
+        }}
+      />
+      <div id="comments" className="mt-4 max-w-5xl">loading comments...</div>
+      <div className="border border-gray rounded-md w-full max-w-5xl">
+        <div className="flex text-sm bg-[#171B21] rounded-md rounded-bl-none rounded-br-none border-gray h-11 border-b pt-2 pl-2">
+          <div className="relative -bottom-px border-t border-l border-r bg-[#0F1116] rounded-md rounded-bl-none rounded-br-none border-gray h-full max-w-min flex items-center p-4">Write</div>
+          <div className="relative -bottom-px text-slate-400 h-full max-w-min flex items-center p-4">Preview</div>
+        </div>
+        <a href="https://snort.social/e/note12qu5r2vnnfpn0kdw77ujxg7r2dzped0tu7038lkh0t4vv9g3vd2qjxr9c7" target="_blank" className="p-2 block">
+          <textarea rows={4} className="w-full bg-black border border-gray rounded-md min-h-full flex h-full" />
+        </a>
+      </div>
     </>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,9 @@
     "**/*.tsx",
     "**/*.cjs",
     "**/*.mjs",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "src/components/comments",
+    "src/components/comments.jsx"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
I am using the script snippet from nostrocket.org to display the comments of a nostr thread

this is just a prototype

- [ ] once @cypherhoodlum has the nostr account ready and posted a generic "Discussion Thread" event, we can change it. 
- [ ] refactor to react (get rid of Script import)
- [ ] add functionality to reply within NostrGit and not link to snort.social



![CleanShot 2023-03-12 at 16 51 01@2x](https://user-images.githubusercontent.com/8019099/224556166-9dd09adb-ab7b-4e73-8581-9fc35d9c86c3.jpg)
