### PR TITLE
vision.md: Fix link to nostr document

### DIFF
--- a/documentation/vision.md
+++ b/documentation/vision.md
@@ -37,4 +37,4 @@ What we have in mind for nrepo:
 
 ## Nostr
 
-Read about the vision of Nostr [here](https://github.com/NostrGit/NostrGit/blob/main/documentation/development/nostr.md).
+Read about the vision of Nostr [here](https://github.com/NostrGit/NostrGit/blob/main/documentation/nostr/nostr.md).


### PR DESCRIPTION
### What does it do? Why?

This PR changes the link in the `vision.md` document to point to the correct location of the `nostr.md` file. The current link yields a 404.

### QA

Confirm that the nostr link no longer 404's.

### Review

- All GHA are success
- Use https://ui.shadcn.com/docs often as possible
- If Vercel build fails, run `yarn build` locally to get the same errors
      more to come...
