### PR TITLE
Implement environment-driven configuration for Nostr relays and repo owner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,24 @@
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"
+
+# Nostr Relay Configuration
+# Frontend (Web UI) relay configuration
+# Comma-separated list of Nostr relay URLs for the web interface
+# If not set, defaults to: wss://relay.damus.io,wss://nos.lol
+NEXT_PUBLIC_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social
+
+# Backend (git-nostr-bridge) relay configuration
+# Comma-separated list of Nostr relay URLs for the backend service
+# Should typically match NEXT_PUBLIC_NOSTR_RELAYS for proper communication
+GIT_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social
+
+# Git Repository Owners (REQUIRED FOR PRODUCTION)
+# Comma-separated list of public keys (hex format) that can create repositories
+# Replace with your actual public key(s) - this controls repository access
+# Example: GIT_NOSTR_REPO_OWNERS=d7a2565a3d29c05a72c315c9117594bb0c76eda7ebfdda3441d0eb6ba326c5e1,another-key-here
+GIT_NOSTR_REPO_OWNERS=your-public-key-hex-here
+
+# Optional: Override default backend paths (usually not needed)
+# GIT_NOSTR_REPOSITORY_DIR=/root/git-nostr-repositories
+# GIT_NOSTR_DB_FILE=/root/.config/git-nostr/git-nostr-db.sqlite

--- a/README.md
+++ b/README.md
@@ -25,9 +25,36 @@ These instructions assume you are not running openSSH Server on port 22 on your 
 $ git clone https://github.com/NostrGit/NostrGit.git
 ```
 
-Edit the `gitnostr/Dockerfile`
-  - replace the public key (hex) with your public key (hex) in the "gitRepoOwners" section of the JSON
-  - optional: add/remove some relays in the "relays" section of the JSON
+**Configure Git Repository Owners (required):**
+
+Set your public key to control who can create repositories:
+
+```bash
+# Replace with your actual public key (hex format)
+$ export GIT_NOSTR_REPO_OWNERS=your-public-key-hex-here
+```
+
+**Configure Nostr Relays (optional):**
+
+You can now configure the Nostr relays for both frontend and backend via environment variables:
+
+```bash
+# Configure relays for both frontend (web UI) and backend (git-nostr-bridge)
+$ export NEXT_PUBLIC_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social
+$ export GIT_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social
+
+# Or use a .env file
+$ cat > .env << EOF
+NEXT_PUBLIC_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol
+GIT_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol
+GIT_NOSTR_REPO_OWNERS=your-public-key-hex-here
+EOF
+
+# Or pass directly to docker compose
+$ GIT_NOSTR_REPO_OWNERS=your-key-here GIT_NOSTR_RELAYS=wss://your.relay.com docker compose up
+```
+
+If no environment variables are set, the application will use default relays: `wss://relay.damus.io` and `wss://nos.lol`.
 
 ```bash
 # change the directory to NostrGit
@@ -35,6 +62,68 @@ $ cd NostrGit
 # run the git-nostr-bridge container
 $ docker compose up > /dev/null 2>&1 &
 ```
+
+## Nostr Relay Configuration
+
+The application now supports flexible relay configuration for both frontend and backend via environment variables instead of hardcoded values.
+
+### Environment Variables
+
+| Variable | Component | Purpose | Default |
+|----------|-----------|---------|---------|
+| `NEXT_PUBLIC_NOSTR_RELAYS` | Frontend (Web UI) | Browsing repos, user interface | `wss://relay.damus.io,wss://nos.lol` |
+| `GIT_NOSTR_RELAYS` | Backend (git-nostr-bridge) | Repository management, SSH access | `wss://relay.damus.io,wss://nos.lol` |
+| `GIT_NOSTR_REPO_OWNERS` | Backend (git-nostr-bridge) | Who can create repositories | `d7a2565a...` (example key) |
+
+### Configuration Methods
+
+1. **System Environment Variables:**
+   ```bash
+   export NEXT_PUBLIC_NOSTR_RELAYS=wss://relay1.com,wss://relay2.io
+   export GIT_NOSTR_RELAYS=wss://relay1.com,wss://relay2.io
+   export GIT_NOSTR_REPO_OWNERS=your-public-key-hex
+   ```
+
+2. **Create .env file:**
+   ```bash
+   cat > .env << EOF
+   NEXT_PUBLIC_NOSTR_RELAYS=wss://relay1.com,wss://relay2.io
+   GIT_NOSTR_RELAYS=wss://relay1.com,wss://relay2.io
+   GIT_NOSTR_REPO_OWNERS=your-public-key-hex
+   EOF
+   ```
+
+3. **Docker Compose Override:**
+   ```bash
+   GIT_NOSTR_REPO_OWNERS=your-key GIT_NOSTR_RELAYS=wss://relay1.com docker compose up
+   ```
+
+4. **Using .env.example as template:**
+   ```bash
+   cp .env.example .env
+   # Edit .env file with your preferred relays and public key
+   ```
+
+### Important Notes
+
+- **Both services should use the same relays** for proper communication
+- **Replace the public key** in `GIT_NOSTR_REPO_OWNERS` with your actual hex public key
+- **Frontend and backend** configurations are now independent but should match
+
+### Default Configuration
+
+If no environment variables are set:
+- **Relays**: `wss://relay.damus.io`, `wss://nos.lol`
+- **Repo Owner**: Example key (must be changed for production)
+
+### Troubleshooting
+
+If you're experiencing connection issues:
+1. Check if the relay URLs are correct and accessible
+2. Verify your network allows WebSocket connections
+3. Ensure both frontend and backend use the same relays
+4. Verify your public key is correctly set in `GIT_NOSTR_REPO_OWNERS`
+5. Try using different relays from the [Nostr relay list](https://nostr.info/relays/)
 
 ## git-nostr-cli
 
@@ -66,11 +155,13 @@ Edit the config file at `~/.config/git-nostr/git-nostr-cli.json`. The file shoul
 
 ```JSON
 {
-    "relays": ["wss://relay.damus.io", "wss://nostr.fmt.wiz.biz", "wss://nos.lol"],
+    "relays": ["wss://relay.damus.io", "wss://nos.lol"],
     "privateKey": "", // your nostr private key (hex)
     "gitSshBase": "root@localhost" // the docker containers expect this
 }
 ```
+
+**Note:** The web interface now supports environment-based relay configuration (see the [Nostr Relay Configuration](#nostr-relay-configuration) section above), but the CLI tool still uses the JSON configuration file.
 
 You need to publish your public ssh key to the nostr relays to be able to interact with the git-nostr-bridge docker container.
 You may need to replace id_rsa.pub with the correct public key file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,20 @@ services:
     ]
     volumes:
       - ./gitnostr/:/home/git-nostr
+    environment:
+      # Frontend (Web UI) relay configuration - comma-separated list of Nostr relay URLs
+      # Example: NEXT_PUBLIC_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol
+      - NEXT_PUBLIC_NOSTR_RELAYS=${NEXT_PUBLIC_NOSTR_RELAYS:-wss://relay.damus.io,wss://nos.lol}
+
+      # Backend (git-nostr-bridge) configuration
+      # Relay configuration for the backend service
+      - GIT_NOSTR_RELAYS=${GIT_NOSTR_RELAYS:-wss://relay.damus.io,wss://nos.lol}
+
+      # Git repository owners (comma-separated list of public keys in hex format)
+      # Replace with your public key(s) - this controls who can create repositories
+      - GIT_NOSTR_REPO_OWNERS=${GIT_NOSTR_REPO_OWNERS:-d7a2565a3d29c05a72c315c9117594bb0c76eda7ebfdda3441d0eb6ba326c5e1}
+
+      # Optional: Override default paths (usually not needed)
+      # - GIT_NOSTR_REPOSITORY_DIR=/root/git-nostr-repositories
+      # - GIT_NOSTR_DB_FILE=/root/.config/git-nostr/git-nostr-db.sqlite
     container_name: git-nostr-bridge

--- a/documentation/development/contributing.md
+++ b/documentation/development/contributing.md
@@ -61,6 +61,21 @@ $ yarn
 $ yarn dev
 ```
 
+### Environment Configuration
+
+For development, you can configure Nostr relays using environment variables:
+
+```bash
+# Create .env file from example
+$ cp .env.example .env
+
+# Or set environment variable directly
+$ export NEXT_PUBLIC_NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol
+
+# Start development server
+$ yarn dev
+```
+
 If you use npm instead of yarn, make sure not to include package-lock.json in the commits.
 
 ## Tooling

--- a/gitnostr/Dockerfile
+++ b/gitnostr/Dockerfile
@@ -21,12 +21,12 @@ RUN CGO_ENABLED=0 go build -tags netgo -ldflags="-s -w" -trimpath -o ./bin/git-n
 RUN CGO_ENABLED=0 go build -tags netgo -ldflags="-s -w" -trimpath -o ./bin/git-nostr-ssh ./cmd/git-nostr-ssh
 RUN CGO_ENABLED=0 go build -tags netgo -ldflags="-s -w" -trimpath -o ./bin/gn ./cmd/git-nostr-cli
 
-# Create config
+# Copy and setup startup script for dynamic configuration
+COPY startup.sh /usr/local/bin/startup.sh
+RUN chmod +x /usr/local/bin/startup.sh
+
+# Create config directory (configuration will be generated dynamically)
 RUN mkdir -p /root/.config/git-nostr
 
-# Configure git-nostr-bridge
-# Replace gitRepoOwners key with your public key (hex)
-RUN echo '{"repositoryDir": "/root/git-nostr-repositories","DbFile": "/root/.config/git-nostr/git-nostr-db.sqlite","relays": ["wss://relay.damus.io", "wss://nostr.fmt.wiz.biz", "wss://nos.lol"],"gitRepoOwners": ["d7a2565a3d29c05a72c315c9117594bb0c76eda7ebfdda3441d0eb6ba326c5e1"]}' > /root/.config/git-nostr/git-nostr-bridge.json
-
-# Set the default command to run when the container starts
-CMD service ssh start && /usr/gitnostr/bin/git-nostr-bridge -config=/root/.config/git-nostr/git-nostr-bridge.json
+# Set the default command to run the startup script
+CMD ["/usr/local/bin/startup.sh"]

--- a/gitnostr/README.md
+++ b/gitnostr/README.md
@@ -101,6 +101,15 @@ Edit the config file at `~/.config/git-nostr/git-nostr-bridge.json`. The default
 Add your relay of relays to the list of relays. **You should use a local relay for testing until the implementation is finalized.**
 Add your public key to the list of gitRepoOwners. **It is recommended to generate a new nostr private/public key pair for testing**
 
+**Note:** This manual JSON configuration is still supported, but the git-nostr-bridge now also supports environment-based configuration via Docker. For production deployments, consider using environment variables instead:
+
+- `GIT_NOSTR_RELAYS` - comma-separated list of relay URLs
+- `GIT_NOSTR_REPO_OWNERS` - comma-separated list of public keys (hex)
+- `GIT_NOSTR_REPOSITORY_DIR` - repository storage directory (optional)
+- `GIT_NOSTR_DB_FILE` - database file path (optional)
+
+Environment variables take precedence and will dynamically generate the configuration file. See the main README.md for full configuration details.
+
 git-nostr-bridge will follow events published by gitRepoOwners and create git repositories for them.
 
 My local testing config looks like this
@@ -111,6 +120,16 @@ My local testing config looks like this
     "DbFile": "~/.config/git-nostr/git-nostr-db.sqlite",
     "relays": ["ws://localhost:8080"],
     "gitRepoOwners": ["e0e7807d354ea7662412d99856335e1923b0b57b6668575bf320837f6b1816e3"]
+}
+```
+
+For production deployments, you might use public relays like:
+```
+{
+    "repositoryDir": "~/git-nostr-repositories",
+    "DbFile": "~/.config/git-nostr/git-nostr-db.sqlite",
+    "relays": ["wss://relay.damus.io", "wss://nos.lol"],
+    "gitRepoOwners": ["your-public-key-hex"]
 }
 ```
 
@@ -164,7 +183,16 @@ My local testing config looks like this
 {
     "relays": ["ws://localhost:8080"],
     "privateKey": "...",
-    "gitSshBase": "git-str@localhost"
+    "gitSshBase": "git-nostr@localhost"
+}
+```
+
+For production deployments, you might use public relays like:
+```
+{
+    "relays": ["wss://relay.damus.io", "wss://nos.lol"],
+    "privateKey": "your-private-key-hex",
+    "gitSshBase": "git-nostr@your-server.com"
 }
 ```
 

--- a/gitnostr/startup.sh
+++ b/gitnostr/startup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Git-Nostr-Bridge Dynamic Configuration Script
+# This script generates git-nostr-bridge.json based on environment variables
+
+CONFIG_DIR="/root/.config/git-nostr"
+CONFIG_FILE="$CONFIG_DIR/git-nostr-bridge.json"
+
+# Create config directory if it doesn't exist
+mkdir -p "$CONFIG_DIR"
+
+# Default values
+DEFAULT_REPOSITORY_DIR="/root/git-nostr-repositories"
+DEFAULT_DB_FILE="/root/.config/git-nostr/git-nostr-db.sqlite"
+DEFAULT_RELAYS="wss://relay.damus.io,wss://nos.lol"
+DEFAULT_GIT_REPO_OWNERS="d7a2565a3d29c05a72c315c9117594bb0c76eda7ebfdda3441d0eb6ba326c5e1"
+
+# Environment variables with defaults
+REPOSITORY_DIR=${GIT_NOSTR_REPOSITORY_DIR:-$DEFAULT_REPOSITORY_DIR}
+DB_FILE=${GIT_NOSTR_DB_FILE:-$DEFAULT_DB_FILE}
+RELAYS=${GIT_NOSTR_RELAYS:-$DEFAULT_RELAYS}
+GIT_REPO_OWNERS=${GIT_NOSTR_REPO_OWNERS:-$DEFAULT_GIT_REPO_OWNERS}
+
+# Convert comma-separated values to JSON arrays
+relays_json=$(echo "$RELAYS" | sed 's/,/","/g' | sed 's/^/"/' | sed 's/$/"/')
+owners_json=$(echo "$GIT_REPO_OWNERS" | sed 's/,/","/g' | sed 's/^/"/' | sed 's/$/"/')
+
+# Generate the configuration file
+cat > "$CONFIG_FILE" << EOF
+{
+    "repositoryDir": "$REPOSITORY_DIR",
+    "DbFile": "$DB_FILE",
+    "relays": [$relays_json],
+    "gitRepoOwners": [$owners_json]
+}
+EOF
+
+echo "Generated git-nostr-bridge configuration:"
+cat "$CONFIG_FILE"
+echo ""
+
+# Start SSH service
+echo "Starting SSH service..."
+service ssh start
+
+# Start git-nostr-bridge with the generated config
+echo "Starting git-nostr-bridge..."
+exec /usr/gitnostr/bin/git-nostr-bridge -config="$CONFIG_FILE"

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -3,6 +3,9 @@ import { z } from "zod";
 /**
  * Specify your server-side environment variables schema here. This way you can ensure the app isn't
  * built with invalid env vars.
+ *
+ * Note: Backend git-nostr-bridge environment variables (GIT_NOSTR_*) are handled directly
+ * by the Docker container and don't need to be included in this Next.js schema.
  */
 const server = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]),
@@ -14,6 +17,7 @@ const server = z.object({
  */
 const client = z.object({
   // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+  NEXT_PUBLIC_NOSTR_RELAYS: z.string().optional(),
 });
 
 /**
@@ -25,6 +29,7 @@ const client = z.object({
 const processEnv = {
   NODE_ENV: process.env.NODE_ENV,
   // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
+  NEXT_PUBLIC_NOSTR_RELAYS: process.env.NEXT_PUBLIC_NOSTR_RELAYS,
 };
 
 // Don't touch the part below

--- a/src/lib/nostr/NostrContext.tsx
+++ b/src/lib/nostr/NostrContext.tsx
@@ -10,6 +10,7 @@ import { type Filter } from "nostr-tools";
 import { nip19 } from "nostr-tools";
 
 import useLocalStorage from "../hooks/useLocalStorage";
+import { env } from "../../env.mjs";
 
 import { WEB_STORAGE_KEYS } from "./localStorage";
 
@@ -27,12 +28,23 @@ declare global {
   }
 }
 
-const defaultRelays = [
-  "wss://relay.damus.io",
-  "wss://nostr.fmt.wiz.biz",
-  // "wss://nostr.bongbong.com", // relay is down
-  "wss://nos.lol",
-];
+// Parse relays from environment variable with fallback to default values
+const getDefaultRelays = (): string[] => {
+  const envRelays = env.NEXT_PUBLIC_NOSTR_RELAYS;
+
+  if (envRelays && envRelays.trim().length > 0) {
+    // Split by comma and trim whitespace from each relay URL
+    return envRelays.split(',').map(relay => relay.trim()).filter(relay => relay.length > 0);
+  }
+
+  // Fallback to hardcoded defaults if env var is not set or empty
+  return [
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+  ];
+};
+
+const defaultRelays = getDefaultRelays();
 const relayPool = new RelayPool(defaultRelays);
 
 const NostrContext = createContext<{


### PR DESCRIPTION
### What does it do? Why?

Replace hardcoded relay URLs and repository owner keys with flexible environment variable configuration for both frontend and backend services.

Benefits:
- Eliminates deployment friction by removing hardcoded values
- Enables environment-specific configuration (dev/staging/prod)
- Improves security by externalizating sensitive configuration
- Follows containerization best practices for config management
- Simplifies testing with different relay providers

Both web interface (`NEXT_PUBLIC_NOSTR_RELAYS`) and git-nostr-bridge (`GIT_NOSTR_RELAYS`) services now support runtime configuration while maintaining backward compatibility with existing setups.

Cheers!

### QA

You should ensure that the service is working properly (well starting and listening).

Apparently your CLI also rely on some config, I don't know if we also want to apply the same logic to the CLI, in all the case it could be done in a follow up patch.

### Review

- All GHA are success
- Use https://ui.shadcn.com/docs often as possible
- If Vercel build fails, run `yarn build` locally to get the same errors
      more to come...
